### PR TITLE
Added newsletter bundling

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,19 +48,14 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 - [Find Your Newsletter](https://findnewsletters.com/) - list of newsletters with categories and search functionality
 - [Inbox Reads](https://inboxreads.co/) - list of newsletters with topics, blog, and search functionality
 - [Inbox Stash](https://inboxstash.com/) - collections of amazing email newsletters on various topics, weekly digest of resources for newsletter creators and picks
-- [Letterdrop](https://letterdrop.io/) - list of recently launched newsletters
 - [Letterlist](https://letterlist.com/) - curated list of newsletters with interviews
 - [mereku](http://mereku.com/) - discover and share newsletter content worth reading
 - [News Bundler](https://newsbundler.com/) - directory with the ability to create bundles
 - [Newsletter Junkie](https://newsletterjunkie.com/) - curated list of newsletters with topics
-- [Newsletter Stack](https://newsletterstack.com/) - list of curated newsletters with topics
 - [Newsletterest](https://newsletterest.com/) - list of newsletters with functionality to see past issues
 - [NewsletterHunt](https://newsletterhunt.com/) - list of newsletters sorted by recently updated
-- [Rad Letters](https://www.radletters.com/) - list of newsletters with topics and interviews
-- [StackHunt](https://stackhunt.xyz/) - list of independent newsletters with categories
 - [Substack Discover](https://substack.com/discover) - list of newsletters using Substack with search functionality
 - [Thanks for Subscribing](https://www.thanksforsubscribing.app/) - curated list of newsletters with topics and search functionality
-- [Viral We Grow Newsletter Listing](https://viralwegrow.com/newsletterlist) - Listing of amazing newsletters on the VWG Community and connecting to their owners
 
 #### Podcasts
 


### PR DESCRIPTION
Added a new category of platforms: Bundling

- Authors team up with one another to increase their revenue by selling newsletter bundles.
- Works by joining their lists and sharing the increased revenue: 36% of a cake of size 4 is more than 100% of a cake of size 1.
- Subscribers get a discount for multiple newsletters.

