### PR TITLE
Add NewsletterStack to newsletter resources list

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 - [Newsletter Junkie](https://newsletterjunkie.com/) - curated list of newsletters with topics
 - [Newsletterest](https://newsletterest.com/) - list of newsletters with functionality to see past issues
 - [NewsletterHunt](https://newsletterhunt.com/) - list of newsletters sorted by recently updated
+- [NewsletterStack](https://www.newsletterstack.co) - curated list of newsletter tools and stacks of successful newsletters
 - [Substack Discover](https://substack.com/discover) - list of newsletters using Substack with search functionality
 - [Thanks for Subscribing](https://www.thanksforsubscribing.app/) - curated list of newsletters with topics and search functionality
 


### PR DESCRIPTION
Hi! I'm adding [NewsletterStack ](https://www.newsletterstack.co/) to the newsletter resources list.

NewsletterStack is a curated directory that features newsletter tools and real-world tech stacks used by successful newsletters. It helps newsletter creators discover what tools and services other newsletters are using to grow and monetize their audiences.

I'm the solo founder and developer of NewsletterStack, and I believe it would be a natural fit for the directories section alongside the other newsletter tool directories listed.

Thanks for maintaining this awesome list!