### PR TITLE
Add JustBlogged to Blog-first platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 
 - [Ghost](https://ghost.org/) - popular CMS for building blogs
 - [Wordpress](https://wordpress.com/) - popular CMS for building sites and blogs
+- [JustBlogged](https://justblogged.com/) - no-setup blogging platform with built-in SEO, start writing in 2 minutes
 
 #### Bundling
 


### PR DESCRIPTION
Adding [JustBlogged](https://justblogged.com/) to the Blog-first platforms section. JustBlogged is a no-setup blogging platform — sign up, pick a name, and start writing in 2 minutes. Free plan available, $9/mo Pro with custom domains, themes, and built-in SEO.