### PR TITLE
Add Scrupp to Deliverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 - [GlockApps](https://glockapps.com/) - tool to diagnose email deliverability problems
 - [GMass](https://www.gmass.co/) - platform used to increase open rates and send bulk emails
 - [Heybounce](https://www.heybounce.io) - Email verification service that checks if an email exists to reduce bounce rates.
+- [Scrupp](https://scrupp.com/) - SMTP-verified email enrichment pulled from LinkedIn/Sales Navigator profiles, useful for building clean B2B newsletter subscriber lists with low bounce rates.
 
 ## Discoverability
 


### PR DESCRIPTION
Adds [Scrupp](https://scrupp.com/) to the **Deliverability** section, same angle as Heybounce.

Scrupp pulls SMTP-verified email addresses from LinkedIn and Sales Navigator profiles, using a multi-provider waterfall for enrichment. For newsletter operators building B2B lists from LinkedIn prospecting (rather than owned-audience signups), this is the sourcing layer that keeps bounce rates low before you send the first send.