### PR TITLE
Add Email Subject Line Tester to Deliverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 ## Deliverability
 
 - [Campaign Cleaner](https://campaigncleaner.com/) - Tool for optimizing HTML email campaigns for better performance.
+- [Email Subject Line Tester](https://alltoolsverse.com/tools/email-subject-line-tester/) - Browser-based subject line analyzer with length guidance, heuristic spam-trigger checks, and mobile and desktop inbox previews.
 - [GlockApps](https://glockapps.com/) - tool to diagnose email deliverability problems
 - [GMass](https://www.gmass.co/) - platform used to increase open rates and send bulk emails
 - [Heybounce](https://www.heybounce.io) - Email verification service that checks if an email exists to reduce bounce rates.


### PR DESCRIPTION
## Summary

Adds the [Email Subject Line Tester](https://alltoolsverse.com/tools/email-subject-line-tester/) to the Deliverability section.

The browser-based tool analyzes subject length, word and emoji counts, heuristic spam triggers, and mobile and desktop inbox previews. Its spam warnings are presented as heuristics rather than authoritative deliverability results.

## Verification

- Tested a subject line with promotional trigger words
- Confirmed character, word, digit, and emoji counts update
- Confirmed spam-trigger detection and risk output
- Confirmed mobile and desktop inbox previews
- Confirmed the repository and pull request history contain no duplicate submission

## Disclosure

I am the maker of All Tools Verse. Codex assisted with repository research, live tool verification, and preparing this focused contribution.