### PR TITLE
Add Autoposting to Marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 - [SendLoop](https://sendloop.com/) - email marketing automation service with a drag-n-drop email builder
 - [Sequenzy](https://www.sequenzy.com/) - email marketing and transactional email platform for SaaS teams
 - [Zoho Campaigns](https://www.zoho.com/campaigns/) - email marketing software that helps businesses drive more sales
+- [Autoposting](https://autoposting.ai) - AI social media manager: generates posts in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube
 
 #### Open source
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 - [SendLoop](https://sendloop.com/) - email marketing automation service with a drag-n-drop email builder
 - [Sequenzy](https://www.sequenzy.com/) - email marketing and transactional email platform for SaaS teams
 - [Zoho Campaigns](https://www.zoho.com/campaigns/) - email marketing software that helps businesses drive more sales
-- [Autoposting](https://autoposting.ai) - AI social media manager: generates posts in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube
+- [Autoposting](https://autoposting.ai) - AI social media manager that writes, clips and schedules posts across five networks
 
 #### Open source
 


### PR DESCRIPTION
Adds [Autoposting](https://autoposting.ai) under Marketing.

AI social media manager, useful next to a newsletter stack for repurposing issues into social posts: writes in your own voice, clips long video, builds carousels, and schedules to X, LinkedIn, Instagram, Threads and YouTube. Free tier available.

One line added, entry style matches the surrounding list.