### PR TITLE
Add Inboxproof to Deliverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 - [GlockApps](https://glockapps.com/) - tool to diagnose email deliverability problems
 - [GMass](https://www.gmass.co/) - platform used to increase open rates and send bulk emails
 - [Heybounce](https://www.heybounce.io) - Email verification service that checks if an email exists to reduce bounce rates.
+- [Inboxproof](https://inboxproof-phi.vercel.app/) - Free, no-signup email deliverability audit: SPF, DKIM, DMARC, TLS and IP reputation in ~30s, with a spam-risk score.
 - [Scrupp](https://scrupp.com/) - SMTP-verified email enrichment pulled from LinkedIn/Sales Navigator profiles, useful for building clean B2B newsletter subscriber lists with low bounce rates.
 
 ## Discoverability


### PR DESCRIPTION
Adding Inboxproof: a free, no-signup email deliverability audit (MX, SPF, DKIM, DMARC, TLS, PTR, IP reputation) that returns a spam-risk score and the exact record to fix. Fits the Deliverability section.