### PR TITLE
Add Email Campaign Preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ A collection of awesome email newsletter tools, platforms, media, and software.
 ## Deliverability
 
 - [Campaign Cleaner](https://campaigncleaner.com/) - Tool for optimizing HTML email campaigns for better performance.
+- [Email Campaign Preflight](https://github.com/Kndll33/email-campaign-preflight-demo) - Offline static HTML campaign QA for links, UTM coverage, image alt text, preheaders, and unsubscribe evidence, with JSON and Markdown reports; not a rendering or deliverability test.
 - [GlockApps](https://glockapps.com/) - tool to diagnose email deliverability problems
 - [GMass](https://www.gmass.co/) - platform used to increase open rates and send bulk emails
 - [Heybounce](https://www.heybounce.io) - Email verification service that checks if an email exists to reduce bounce rates.


### PR DESCRIPTION
Adds one concise entry for Email Campaign Preflight next to Campaign Cleaner. The linked public evaluation page includes reproducible sample reports, pricing, scope boundaries, and a proof-first pilot path. The description explicitly says it is not a rendering or deliverability test.